### PR TITLE
[18.0][IMP] excel_import_export: replace reading excel file from xlrd with openpyxl

### DIFF
--- a/excel_import_export/models/xlsx_import.py
+++ b/excel_import_export/models/xlsx_import.py
@@ -14,6 +14,7 @@ import xlwt
 from odoo import api, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools.float_utils import float_compare
+from odoo.tools.parse_version import parse_version
 from odoo.tools.safe_eval import safe_eval
 
 from . import common as co
@@ -97,19 +98,31 @@ class XLSXImport(models.AbstractModel):
             raise ValidationError(self.env._("Error deleting data\n%s", e)) from e
 
     @api.model
-    def _get_end_row(self, st, worksheet, line_field):
+    def _get_end_row(self, st, worksheet, line_field, is_xlsx=False):
         """Get max row or next empty row as the ending row"""
         _x, max_row = co.get_line_max(line_field)
         test_rows = {}
         max_end_row = 0
+        if is_xlsx:
+            # For openpyxl
+            sheet_nrows = st.max_row
+        else:
+            # For xlrd
+            sheet_nrows = st.nrows
         for rc, _col in worksheet.get(line_field, {}).items():
             rc, key_eval_cond = co.get_field_condition(rc)
             row, col = co.pos2idx(rc)
             # Use max_row, i.e., order_line[5], use it. Otherwise, use st.nrows
-            max_end_row = st.nrows if max_row is False else (row + max_row)
-            for idx in range(row, max_row and max_end_row or st.nrows):
+            max_end_row = sheet_nrows if max_row is False else (row + max_row)
+            for idx in range(row, max_row and max_end_row or sheet_nrows):
                 try:
-                    cell_type = st.cell_type(idx, col)  # empty type = 0
+                    if is_xlsx:
+                        # openpyxl uses 1-based indexing
+                        cell = st.cell(row=idx + 1, column=col + 1)
+                        # Check if cell is empty (None or empty string)
+                        cell_type = 0 if cell.value in (None, "") else 1
+                    else:
+                        cell_type = st.cell_type(idx, col)  # empty type = 0
                 except Exception as e:
                     raise UserError(
                         self.env._(
@@ -129,10 +142,10 @@ class XLSXImport(models.AbstractModel):
         return next_empty_row
 
     @api.model
-    def _get_line_vals(self, st, worksheet, model, line_field):
+    def _get_line_vals(self, st, worksheet, model, line_field, is_xlsx=False):
         """Get values of this field from excel sheet"""
         vals = {}
-        end_row = self._get_end_row(st, worksheet, line_field)
+        end_row = self._get_end_row(st, worksheet, line_field, is_xlsx)
         for rc, columns in worksheet.get(line_field, {}).items():
             if not isinstance(columns, list):
                 columns = [columns]
@@ -145,7 +158,11 @@ class XLSXImport(models.AbstractModel):
                 field_type = self._get_field_type(model, out_field)
                 vals.update({out_field: []})
                 for idx in range(row, end_row):
-                    value = co._get_cell_value(st.cell(idx, col), field_type=field_type)
+                    if is_xlsx:  # Handle openpyxl cells
+                        cell_value = st.cell(row=idx + 1, column=col + 1)
+                    else:  # Handle xlrd cells
+                        cell_value = st.cell(idx, col)
+                    value = co._get_cell_value(cell_value, field_type=field_type)
                     eval_context = self.get_eval_context(model=model, value=value)
                     if key_eval_cond:
                         value = safe_eval(key_eval_cond, eval_context)
@@ -157,15 +174,27 @@ class XLSXImport(models.AbstractModel):
         return vals
 
     @api.model
-    def _process_worksheet(self, wb, out_wb, out_st, model, data_dict, header_fields):
+    def _process_worksheet(
+        self, wb, out_st, model, data_dict, header_fields, is_xlsx=False
+    ):  # noqa: C901
         col_idx = 1
         for sheet_name in data_dict:  # For each Sheet
             worksheet = data_dict[sheet_name]
-            st = False
+            st = None
             if isinstance(sheet_name, str):
-                st = co.xlrd_get_sheet_by_name(wb, sheet_name)
+                # Get sheet by name for openpyxl
+                st = (
+                    wb[sheet_name]
+                    if is_xlsx
+                    else co.xlrd_get_sheet_by_name(wb, sheet_name)
+                )
             elif isinstance(sheet_name, int):
-                st = wb.sheet_by_index(sheet_name - 1)
+                # Get sheet by index for openpyxl
+                st = (
+                    wb.worksheets[sheet_name - 1]
+                    if is_xlsx
+                    else wb.sheet_by_index(sheet_name - 1)
+                )
             if not st:
                 raise ValidationError(self.env._("Sheet %s not found", sheet_name))
             # HEAD updates
@@ -175,7 +204,12 @@ class XLSXImport(models.AbstractModel):
                 field_type = self._get_field_type(model, field)
                 try:
                     row, col = co.pos2idx(rc)
-                    value = co._get_cell_value(st.cell(row, col), field_type=field_type)
+                    if is_xlsx:  # openpyxl
+                        # openpyxl uses 1-based indexing
+                        cell_value = st.cell(row=row + 1, column=col + 1).value
+                    else:  # xlrd
+                        cell_value = st.cell(row, col)
+                    value = co._get_cell_value(cell_value, field_type=field_type)
                 except Exception:
                     value = False
                 eval_context = self.get_eval_context(model=model, value=value)
@@ -190,7 +224,7 @@ class XLSXImport(models.AbstractModel):
             # Line Items
             line_fields = filter(lambda x: x != "_HEAD_", worksheet)
             for line_field in line_fields:
-                vals = self._get_line_vals(st, worksheet, model, line_field)
+                vals = self._get_line_vals(st, worksheet, model, line_field, is_xlsx)
                 for field in vals:
                     # Columns, i.e., line_ids/field_id
                     out_st.write(0, col_idx, field)
@@ -204,27 +238,43 @@ class XLSXImport(models.AbstractModel):
 
     @api.model
     def _import_record_data(self, import_file, record, data_dict):
-        """From complex excel, create temp simple excel and do import"""
         if not data_dict:
             return
         try:
             header_fields = []
             model = record._name
-            decoded_data = base64.decodebytes(import_file)
-            wb = xlrd.open_workbook(file_contents=decoded_data)
-            out_wb = xlwt.Workbook()
-            out_st = out_wb.add_sheet("Sheet 1")
             xml_id = (
                 record
                 and self.get_external_id(record)
                 or "{}.{}".format("__excel_import_export__", uuid.uuid4())
             )
-            out_st.write(0, 0, "id")  # id and xml_id on first column
+            decoded_data = base64.decodebytes(import_file)
+            out_wb = xlwt.Workbook()
+            out_st = out_wb.add_sheet("Sheet 1")
+            out_st.write(0, 0, "id")
             out_st.write(1, 0, xml_id)
             header_fields.append("id")
+            is_xlsx = False
+            if xlrd and parse_version(xlrd.__VERSION__) < parse_version("2.0"):
+                wb = xlrd.open_workbook(file_contents=decoded_data)
+            else:
+                try:
+                    import io
+
+                    from openpyxl import load_workbook
+
+                    wb = load_workbook(io.BytesIO(decoded_data or b""), data_only=True)
+                    is_xlsx = True
+                except Exception as exc:
+                    raise ValidationError(
+                        self.env._(
+                            "Invalid file style, only .xls or .xlsx file allowed"
+                        )
+                    ) from exc
             # Process on all worksheets
-            self._process_worksheet(wb, out_wb, out_st, model, data_dict, header_fields)
-            # --
+            self._process_worksheet(
+                wb, out_st, model, data_dict, header_fields, is_xlsx
+            )
             content = BytesIO()
             out_wb.save(content)
             content.seek(0)  # Set index to 0, and start reading

--- a/excel_import_export/models/xlsx_import.py
+++ b/excel_import_export/models/xlsx_import.py
@@ -241,36 +241,16 @@ class XLSXImport(models.AbstractModel):
         if not data_dict:
             return
         try:
-            header_fields = []
             model = record._name
-            xml_id = (
-                record
-                and self.get_external_id(record)
-                or "{}.{}".format("__excel_import_export__", uuid.uuid4())
-            )
+            xml_id = self._generate_xml_id(record)
             decoded_data = base64.decodebytes(import_file)
             out_wb = xlwt.Workbook()
             out_st = out_wb.add_sheet("Sheet 1")
             out_st.write(0, 0, "id")
             out_st.write(1, 0, xml_id)
-            header_fields.append("id")
-            is_xlsx = False
-            if xlrd and parse_version(xlrd.__VERSION__) < parse_version("2.0"):
-                wb = xlrd.open_workbook(file_contents=decoded_data)
-            else:
-                try:
-                    import io
-
-                    from openpyxl import load_workbook
-
-                    wb = load_workbook(io.BytesIO(decoded_data or b""), data_only=True)
-                    is_xlsx = True
-                except Exception as exc:
-                    raise ValidationError(
-                        self.env._(
-                            "Invalid file style, only .xls or .xlsx file allowed"
-                        )
-                    ) from exc
+            header_fields = ["id"]
+            is_xlsx = self._is_xlsx_file()
+            wb = self._load_workbook(decoded_data, is_xlsx)
             # Process on all worksheets
             self._process_worksheet(
                 wb, out_st, model, data_dict, header_fields, is_xlsx
@@ -280,40 +260,10 @@ class XLSXImport(models.AbstractModel):
             content.seek(0)  # Set index to 0, and start reading
             xls_file = content.read()
             # Do the import
-            Import = self.env["base_import.import"]
-            imp = Import.create(
-                {
-                    "res_model": model,
-                    "file": xls_file,
-                    "file_type": "application/vnd.ms-excel",
-                    "file_name": "temp.xls",
-                }
-            )
-            errors = imp.execute_import(
-                header_fields,
-                header_fields,
-                {
-                    "has_headers": True,
-                    "advanced": True,
-                    "keep_matches": False,
-                    "encoding": "",
-                    "separator": "",
-                    "quoting": '"',
-                    "date_format": "%Y-%m-%d",
-                    "datetime_format": "%Y-%m-%d %H:%M:%S",
-                    "float_thousand_separator": ",",
-                    "float_decimal_separator": ".",
-                    "fields": [],
-                },
-            )
+            imp = self._create_import_record(model, xls_file)
+            errors = self._execute_import(imp, header_fields)
             if errors.get("messages"):
-                message = self.env._("Error importing data")
-                messages = errors["messages"]
-                if isinstance(messages, dict):
-                    message = messages["message"]
-                if isinstance(messages, list):
-                    message = ", ".join([x["message"] for x in messages])
-                raise ValidationError(message.encode("utf-8"))
+                self._handle_import_errors(errors)
             return self.env.ref(xml_id)
         except xlrd.XLRDError as exc:
             raise ValidationError(
@@ -321,6 +271,71 @@ class XLSXImport(models.AbstractModel):
             ) from exc
         except Exception as e:
             raise e
+
+    def _generate_xml_id(self, record):
+        return (
+            record
+            and self.get_external_id(record)
+            or "{}.{}".format("__excel_import_export__", uuid.uuid4())
+        )
+
+    def _is_xlsx_file(self):
+        if xlrd and parse_version(xlrd.__VERSION__) < parse_version("2.0"):
+            return False
+        return True
+
+    def _load_workbook(self, decoded_data, is_xlsx):
+        if not is_xlsx:
+            return xlrd.open_workbook(file_contents=decoded_data)
+        try:
+            import io
+
+            from openpyxl import load_workbook
+
+            return load_workbook(io.BytesIO(decoded_data or b""), data_only=True)
+        except Exception as exc:
+            raise ValidationError(
+                self.env._("Invalid file style, only .xls or .xlsx file allowed")
+            ) from exc
+
+    def _create_import_record(self, model, xls_file):
+        Import = self.env["base_import.import"]
+        return Import.create(
+            {
+                "res_model": model,
+                "file": xls_file,
+                "file_type": "application/vnd.ms-excel",
+                "file_name": "temp.xls",
+            }
+        )
+
+    def _execute_import(self, imp, header_fields):
+        return imp.execute_import(
+            header_fields,
+            header_fields,
+            {
+                "has_headers": True,
+                "advanced": True,
+                "keep_matches": False,
+                "encoding": "",
+                "separator": "",
+                "quoting": '"',
+                "date_format": "%Y-%m-%d",
+                "datetime_format": "%Y-%m-%d %H:%M:%S",
+                "float_thousand_separator": ",",
+                "float_decimal_separator": ".",
+                "fields": [],
+            },
+        )
+
+    def _handle_import_errors(self, errors):
+        message = self.env._("Error importing data")
+        messages = errors["messages"]
+        if isinstance(messages, dict):
+            message = messages["message"]
+        if isinstance(messages, list):
+            message = ", ".join([x["message"] for x in messages])
+        raise ValidationError(message.encode("utf-8"))
 
     @api.model
     def _post_import_operation(self, record, operation):


### PR DESCRIPTION
- `xlrd >= 2.0` removed `xlsx` support, ref: https://github.com/python-excel/xlrd/blob/0c4e80b3d48dfe2250ac4e514c8231a742fee221/xlrd/__init__.py#L138
- actually `xlrd` still works fine when reading excel files in lower versions (example `xlrd==1.2.0`), so I just bound the simple check condition, ref: https://github.com/odoo/odoo/blob/de22c88aa475be2ab8413c3fc4632db4a622e134/requirements.txt#L85
- the replacement using `openpyxl` to support this file type was done in a migration from version `14.0` to `15.0`, see: https://github.com/odoo/odoo/pull/169245/commits/68e3699fbe53e709622ecee93f991b8ed35233af
- I also took this opportunity to remove the `out_wb` parameter from the `_process_worksheet` function, as it was redundant.